### PR TITLE
Add filters, options and some additions to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # metalsmith-debug
 
-A Metalsmith plugin to debug Metalsmith and plugins.
+A Metalsmith plugin to debug Metalsmith and plugins. It is a thin wrapper around [debug](https://github.com/visionmedia/debug) making use of its namespaces and logging functionality.
 
 ## Installation
 
@@ -19,25 +19,30 @@ Install via npm and then add the `metalsmith-debug` key to your `metalsmith.json
   }
 }
 ```
-Then you can:
+
+## Available namespaces
+
+Available namespaces defined by `metalsmith-debug` are:
+
+* metalsmith:source
+* metalsmith:destination
+* metalsmith:metadata
+* metalsmith:files
+* metalsmith:log
+
+To see debug messages, you must set a `DEBUG` environment variable to the desired namespaces.
+
+For all debug messages you can define:
 
 ```
 $ DEBUG=metalsmith:* metalsmith
 ```
-To see all debug messages.
 
 Or you can use namespaces to see only necessary messages:
 
 ```
 $ DEBUG=metalsmith:files metalsmith
 ```
-
-Available namespaces:
-
-* metalsmith:source
-* metalsmith:destination
-* metalsmith:metadata
-* metalsmith:files
 
 If you want to debug a specific plugin you must name it:
 
@@ -60,6 +65,25 @@ var debug = require('metalsmith-debug');
 
 metalsmith.use(debug());
 ```
+
+## Options
+
+In case you want to use `.use(debug())` several times in your Metalsmith chain you have some options to switch off some of the `metalsmith:*` namespaces. Additionally, you can add some arbitrary log text. Furthermore you can filter for files if you only want to monitor certain files. The filter option is based on the globbing patterns implemented by [multimatch](https://github.com/sindresorhus/multimatch).
+
+```js
+var debug = require('metalsmith-debug');
+
+metalsmith.use(debug({
+  log: "first debug",      // any comment you like
+  metadata: false,         // default: true
+  source: false,           // default: true
+  destination: false,      // default: true
+  files: true,             // default: true
+  filter: "**/*.md"        // default: all files
+}));
+```
+
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ metalsmith.use(debug());
 
 ## Options
 
-In case you want to use `.use(debug())` several times in your Metalsmith chain you have some options to switch off some of the `metalsmith:*` namespaces. Additionally, you can add some arbitrary log text. Furthermore you can filter for files if you only want to monitor certain files. The filter option is based on the globbing patterns implemented by [multimatch](https://github.com/sindresorhus/multimatch).
+In case you want to use `.use(debug())` several times in your Metalsmith chain you have some options to switch off some of the `metalsmith:*` namespaces. Additionally, you can add some arbitrary log text. Furthermore you can apply file matching if you only want to monitor certain files. The `match` option is based on the globbing patterns implemented by [multimatch](https://github.com/sindresorhus/multimatch).
 
 ```js
 var debug = require('metalsmith-debug');
@@ -79,7 +79,7 @@ metalsmith.use(debug({
   source: false,           // default: true
   destination: false,      // default: true
   files: true,             // default: true
-  filter: "**/*.md"        // default: all files
+  match: "**/*.md"         // default: all files
 }));
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,10 +52,9 @@ module.exports = function plugin(options) {
                   'no namespaces are set in DEBUG environment');
       console.log('  metalsmith-debug: ' +
                   'set DEBUG=metalsmith:* for all namespaces');
-      return;
     }
 
-    if (options.log) {
+    if (options.log.length) {
       debugLog('"%s"', options.log);
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ module.exports = function plugin(options) {
   options.destination = (options.destination === undefined) ?
                         true : options.destination;
   options.files = (options.files === undefined) ? true : options.files;
-  options.filter = (options.filter === undefined) ? '' : options.filter;
+  options.match = (options.match === undefined) ? '' : options.match;
   options.log = (options.log === undefined) ? '' : options.log;
 
 
@@ -75,9 +75,9 @@ module.exports = function plugin(options) {
       debugMetadata('', inspect(metalsmith.metadata()));
     }
 
-    if (options.filter.length) {
+    if (options.match.length) {
       Object.keys(files).forEach(function(file){
-        if (!multimatch(file, options.filter).length) delete files2log[file];
+        if (!multimatch(file, options.match).length) delete files2log[file];
       });
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,15 @@
 
-var util = require('util');
-var debug = require('debug');
+var _                = require('lodash');
+var debug            = require('debug');
+var multimatch       = require('multimatch');
+var util             = require('util');
 
-var debugSource = debug('metalsmith:source');
+
+var debugSource      = debug('metalsmith:source');
 var debugDestination = debug('metalsmith:destination');
-var debugMetadata = debug('metalsmith:metadata');
-var debugFiles = debug('metalsmith:files');
+var debugMetadata    = debug('metalsmith:metadata');
+var debugFiles       = debug('metalsmith:files');
+var debugLog         = debug('metalsmith:log');
 
 
 /**
@@ -25,15 +29,61 @@ function inspect(obj) {
  * @return {Function}
  */
 
-module.exports = function plugin() {
+module.exports = function plugin(options) {
+  options = (options === undefined) ? {} : options;
+  options.metadata = (options.metadata === undefined) ?
+                     true : options.metadata;
+  options.source = (options.source === undefined) ?
+                   true : options.source;
+  options.destination = (options.destination === undefined) ?
+                        true : options.destination;
+  options.files = (options.files === undefined) ? true : options.files;
+  options.filter = (options.filter === undefined) ? '' : options.filter;
+  options.log = (options.log === undefined) ? '' : options.log;
+
 
   return function(files, metalsmith, done) {
 
-    debugSource('"%s"', metalsmith.source());
-    debugDestination('"%s"', metalsmith.destination());
+    if (process.env.DEBUG) {
+      console.log('  metalsmith-debug: ' +
+                  'namespaces set to DEBUG=%s', process.env.DEBUG);
+    }
+    else {
+      console.log('  metalsmith-debug: ' +
+                  'no namespaces are set in DEBUG environment');
+      console.log('  metalsmith-debug: ' +
+                  'set DEBUG=metalsmith:* for all namespaces');
+      return;
+    }
 
-    debugMetadata('', inspect(metalsmith.metadata()));
-    debugFiles('', inspect(files));
+
+    var files2log = _.cloneDeep(files);
+
+    if (options.log) {
+      debugLog('"%s"', options.log);
+    }
+
+    if (options.source) {
+      debugSource('"%s"', metalsmith.source());
+    }
+
+    if (options.destination) {
+      debugDestination('"%s"', metalsmith.destination());
+    }
+
+    if (options.metadata) {
+      debugMetadata('', inspect(metalsmith.metadata()));
+    }
+
+    if (options.filter.length) {
+      Object.keys(files).forEach(function(file){
+        if (!multimatch(file, options.filter).length) delete files2log[file];
+      });
+    }
+
+    if (options.files) {
+      debugFiles('', inspect(files2log));
+    }
 
     done();
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 
-var _                = require('lodash');
 var debug            = require('debug');
 var multimatch       = require('multimatch');
 var util             = require('util');
@@ -56,9 +55,6 @@ module.exports = function plugin(options) {
       return;
     }
 
-
-    var files2log = _.cloneDeep(files);
-
     if (options.log) {
       debugLog('"%s"', options.log);
     }
@@ -75,10 +71,17 @@ module.exports = function plugin(options) {
       debugMetadata('', inspect(metalsmith.metadata()));
     }
 
+
+    var files2log = {};
+
     if (options.match.length) {
       Object.keys(files).forEach(function(file){
-        if (!multimatch(file, options.match).length) delete files2log[file];
+        if (multimatch(file, options.match).length) {
+          files2log[file] = files[file];
+        }
       });
+    } else {
+      files2log = files;
     }
 
     if (options.files) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^2.2.0",
-    "lodash": "^4.1.3",
     "multimatch": "^2.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "debug": "^2.2.0"
+    "debug": "^2.2.0",
+    "lodash": "^4.1.3",
+    "multimatch": "^2.1.0"
   },
   "devDependencies": {
     "jshint": "^2.5.1"


### PR DESCRIPTION
I have been working on metalsmith [PR #237](https://github.com/metalsmith/metalsmith/pull/237) and think about adding `metalsmith-debug`. But before I wanted to add:
- some clarifications in the Readme.md
- add a console.log for the `process.env.DEBUG`
- add matching, if one only wants to monitor certain files and not all files
- switches to switch off individual namespaces if `.use(debug())` is used several times in a Metalsmith chain.

@mahnunchik What do you think?
