### PR TITLE
Add fileNames as a debug option to only display filenames

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var debugSource      = debug('metalsmith:source');
 var debugDestination = debug('metalsmith:destination');
 var debugMetadata    = debug('metalsmith:metadata');
 var debugFiles       = debug('metalsmith:files');
+var debugFileNames   = debug('metalsmith:filenames')
 var debugLog         = debug('metalsmith:log');
 
 
@@ -37,6 +38,7 @@ module.exports = function plugin(options) {
   options.destination = (options.destination === undefined) ?
                         true : options.destination;
   options.files = (options.files === undefined) ? true : options.files;
+  options.fileNames = (options.fileNames === undefined) ? false : options.fileNames;
   options.match = (options.match === undefined) ? '' : options.match;
   options.log = (options.log === undefined) ? false : options.log;
 
@@ -74,6 +76,10 @@ module.exports = function plugin(options) {
 
     if (options.files) {
       debugFiles(inspect(files2log));
+    }
+
+    if (options.fileNames){
+      debugFileNames(inspect(Object.keys(files2log)));
     }
 
     done();


### PR DESCRIPTION
I've often found I only need to see which files are being processed by metalsmith, and not each and every file's full contents. This adds a `fileNames: boolean` option, defaulting as false, to debug file names. As is, users will probably want to set files to false when using this option.